### PR TITLE
폴더 제거 방식 수정

### DIFF
--- a/SimpleNote/Service/Database/FolderDatabase.swift
+++ b/SimpleNote/Service/Database/FolderDatabase.swift
@@ -38,6 +38,12 @@ extension FolderDatabase: DependencyKey {
     delete: { folder in
       @Dependency(\.database.context) var context
       let folderContext = try context()
+      
+      /// CloudKit을 사용하면 cascade가 제대로 동작하지 않음
+      /// 따라서 폴더 제거할 때 내부에 있는 Todo를 모두 제거
+      folder.todos?.forEach {
+        folderContext.delete($0)
+      }
       folderContext.delete(folder)
     },
     deleteAll: {


### PR DESCRIPTION
- 폴더 제거 방식 수정
  - SwiftData에서 제공하는 RelationShip에서 제거 방식인 cascade가 있음
  - 그러나 CloudKit을 사용하면 해당 연관 관계의 데이터를 제거하지 않음
  - 따라서 해당 모델을 제거하기 전에 연결된 서브 모델을 모두 제거해야 함

([참조](https://forums.developer.apple.com/forums/thread/740649)) 